### PR TITLE
[Hive-23809] mapred.reduce.tasks data-loss patch for bucketed table + auth user email domain . to _ bug fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+
+* @premal @6si/codeowners-big-data-engineering
+CODEOWNERS  @6si/codeowners-approvers @6si/codeowners-big-data-engineering

--- a/beeline/src/java/org/apache/hive/beeline/Commands.java
+++ b/beeline/src/java/org/apache/hive/beeline/Commands.java
@@ -1627,7 +1627,7 @@ public class Commands {
       if (username == null) {
         username = beeLine.getConsoleReader().readLine("Enter username for " + urlForPrompt + ": ");
       }
-      props.setProperty(JdbcConnectionParams.AUTH_USER, username.replace(".", "_"));
+      props.setProperty(JdbcConnectionParams.AUTH_USER, Utils.sanitizeAuthUser(username));
       if (password == null) {
         password = beeLine.getConsoleReader().readLine("Enter password for " + urlForPrompt + ": ",
           new Character('*'));

--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -218,7 +218,8 @@ public class Utils {
 
     public Map<String, String> getSessionVars() {
       if (sessionVars.containsKey(JdbcConnectionParams.AUTH_USER)) {
-	      sessionVars.put(JdbcConnectionParams.AUTH_USER, sessionVars.get(JdbcConnectionParams.AUTH_USER).replace(".","_"));
+	      sessionVars.put(JdbcConnectionParams.AUTH_USER,
+	          Utils.sanitizeAuthUser(sessionVars.get(JdbcConnectionParams.AUTH_USER)));
       }
       return sessionVars;
     }
@@ -449,7 +450,7 @@ public class Utils {
     if (!connParams.getSessionVars().containsKey(JdbcConnectionParams.AUTH_USER)) {
       if (info.containsKey(JdbcConnectionParams.AUTH_USER)) {
         connParams.getSessionVars().put(JdbcConnectionParams.AUTH_USER,
-            info.getProperty(JdbcConnectionParams.AUTH_USER).replace(".","_"));
+            Utils.sanitizeAuthUser(info.getProperty(JdbcConnectionParams.AUTH_USER)));
       }
       if (info.containsKey(JdbcConnectionParams.AUTH_PASSWD)) {
         connParams.getSessionVars().put(JdbcConnectionParams.AUTH_PASSWD,
@@ -707,6 +708,28 @@ public class Utils {
       LOG.warn("Could not retrieve canonical hostname for " + hostName, exception);
       return hostName;
     }
+  }
+
+
+  /**
+   * Sanitizes the authentication user by replacing dots with underscores.
+   * This is used to ensure compatibility with certain authentication systems
+   * that may not handle dots in usernames properly.
+   *
+   * @param user The original username string
+   * @return The sanitized username with dots replaced by underscores,
+   *         or null if the input is null
+   */
+  public static String sanitizeAuthUser(final String user) {
+    if (user == null) {
+      return null;
+    }
+    final int at = user.indexOf('@');
+    if (at < 0) {
+      return user.replace('.', '_');
+    }
+    final String localPart = user.substring(0, at).replace('.', '_');
+    return localPart + user.substring(at);
   }
 
 }

--- a/jdbc/src/test/org/apache/hive/jdbc/TestUtils.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.jdbc;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(JUnit4.class)
+public class TestUtils {
+
+  @Test
+  public void testSanitizeAuthUserNull() {
+    assertNull("Null input should return null", Utils.sanitizeAuthUser(null));
+  }
+
+  @Test
+  public void testSanitizeAuthUserWithoutAt() {
+    assertEquals("user.name should become user_name", 
+        "user_name", Utils.sanitizeAuthUser("user.name"));
+    assertEquals("user.name.test should become user_name_test", 
+        "user_name_test", Utils.sanitizeAuthUser("user.name.test"));
+    assertEquals("username without dots should remain unchanged", 
+        "username", Utils.sanitizeAuthUser("username"));
+    assertEquals("empty string should remain empty", 
+        "", Utils.sanitizeAuthUser(""));
+  }
+
+  @Test
+  public void testSanitizeAuthUserWithEmail() {
+    assertEquals("user.name@domain.com should become user_name@domain.com", 
+        "user_name@domain.com", Utils.sanitizeAuthUser("user.name@domain.com"));
+    assertEquals("user.name.test@sub.domain.com should become user_name_test@sub.domain.com", 
+        "user_name_test@sub.domain.com", Utils.sanitizeAuthUser("user.name.test@sub.domain.com"));
+    assertEquals("username@domain.com should remain unchanged", 
+        "username@domain.com", Utils.sanitizeAuthUser("username@domain.com"));
+    assertEquals("user@domain.com should remain unchanged", 
+        "user@domain.com", Utils.sanitizeAuthUser("user@domain.com"));
+  }
+
+  @Test
+  public void testSanitizeAuthUserEdgeCases() {
+    assertEquals("@domain.com should remain unchanged", 
+        "@domain.com", Utils.sanitizeAuthUser("@domain.com"));
+    assertEquals("user@ should remain unchanged", 
+        "user@", Utils.sanitizeAuthUser("user@"));
+    assertEquals("user.@domain.com should become user_@domain.com", 
+        "user_@domain.com", Utils.sanitizeAuthUser("user.@domain.com"));
+    assertEquals(".user@domain.com should become _user@domain.com", 
+        "_user@domain.com", Utils.sanitizeAuthUser(".user@domain.com"));
+    assertEquals("user.name.@domain.com should become user_name_@domain.com", 
+        "user_name_@domain.com", Utils.sanitizeAuthUser("user.name.@domain.com"));
+    assertEquals("multiple..dots@domain.com should become multiple__dots@domain.com", 
+        "multiple__dots@domain.com", Utils.sanitizeAuthUser("multiple..dots@domain.com"));
+  }
+
+  @Test
+  public void testSanitizeAuthUserMultipleAtSymbols() {
+    assertEquals("user.name@domain@other.com should become user_name@domain@other.com", 
+        "user_name@domain@other.com", Utils.sanitizeAuthUser("user.name@domain@other.com"));
+    assertEquals("user@domain.com@extra should become user@domain.com@extra", 
+        "user@domain.com@extra", Utils.sanitizeAuthUser("user@domain.com@extra"));
+  }
+}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 # Hive Development Build and Management Tasks
 
+## Variables
+main_hive2_branch := "6si-main"
+main_hive3_branch := "6si-hive3-main"
+
 set shell := ["bash", "-c"]
 
 # Default recipe - show help
@@ -94,7 +98,22 @@ build-with-tests:
     echo "=== building with tests ==="
     mvn clean install -Pdist -Dtar -Dmaven.javadoc.skip=true
 
-build-dist: build-with-tests
+pull-main:
+    #!/bin/bash
+    # pull if current is one of main branch
+    if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      branch="$(git branch --show-current 2>/dev/null || true)"
+      commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
+    fi
+    if [ -n "${branch}" ] && { [ "${branch}" = "${main_hive2_branch}" ] || [ "${branch}" = "${main_hive3_branch}" ]; }; then
+      echo "Current branch is ${branch}, pulling latest changes..."
+      git pull origin "${branch}"
+      echo "Pull completed"
+    else
+      echo "Not on a main branch (current: ${branch:-no-branch}), skipping pull"
+    fi 
+
+build-dist: pull-main build-with-tests 
     #!/bin/bash
     file_name="apache-hive-3.1.3-bin.tar.gz"
     tar_generation_dir="hive_build_dist"
@@ -158,6 +177,26 @@ upload-tar bucket_name='6si-customers-adhoc' prefix='big_data/resources/': aws-l
     aws s3 cp "${file}" "${dest}"  --profile=default-engineering
 
 
+upload-jar jar_path bucket_name='6si-customers-adhoc' prefix='big_data/resources/': aws-login
+    #!/bin/bash
+    if [ -z "{{jar_path}}" ]; then
+      echo "ERROR: jar_path is required";
+      echo "Usage: just upload-jar <jar_path> [bucket_name] [prefix]";
+      exit 2;
+    fi
+    if [ ! -f "{{jar_path}}" ]; then
+      echo "ERROR: JAR file not found: {{jar_path}}";
+      exit 2;
+    fi
+    p="{{prefix}}"
+    if [ -n "${p}" ] && [ "${p: -1}" != "/" ]; then
+      p="${p}/"
+    fi
+    dest="s3://{{bucket_name}}/${p}$(basename "{{jar_path}}")"
+    echo "Uploading {{jar_path}} -> ${dest}"
+    aws s3 cp "{{jar_path}}" "${dest}"  --profile=default-engineering
+    
+
 # ============================================================================
 # Module-specific Build Tasks
 # ============================================================================
@@ -167,8 +206,14 @@ build-core:
     cd core && mvn clean install -DskipTests=true
 
 # Build QL module
-build-ql:
-    cd ql && mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true
+build-ql skip-tests="true":
+    #!/bin/bash
+    if [ "{{skip-tests}}" = "true" ]; then
+      cd ql && mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true
+    else
+      echo "=== building ql with tests ==="
+      cd ql && mvn clean install -Dmaven.javadoc.skip=true
+    fi
 
 # Build metastore module
 build-metastore:

--- a/justfile
+++ b/justfile
@@ -92,14 +92,23 @@ build-without-tests:
 # Build with tests (slower, comprehensive)
 build-with-tests:
     echo "=== building with tests ==="
-    # mvn clean install -Pdist -Dtar -Dmaven.javadoc.skip=true
+    mvn clean install -Pdist -Dtar -Dmaven.javadoc.skip=true
 
 build-dist: build-with-tests
     #!/bin/bash
     file_name="apache-hive-3.1.3-bin.tar.gz"
     tar_generation_dir="hive_build_dist"
     ts="$(date -u +%Y%m%dT%H%M%SZ)"
-    gdp_tar_name="apache-hive-3.1.3-bin-gdp-${ts}.tar.gz"
+    branch="no-branch"
+    commit="no-commit"
+    if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      branch="$(git branch --show-current 2>/dev/null || true)"
+      commit="$(git rev-parse --short HEAD 2>/dev/null || true)"
+    fi
+    if [ -z "${branch}" ]; then branch="no-branch"; fi
+    if [ -z "${commit}" ]; then commit="no-commit"; fi
+    branch_sanitized="${branch//\//-}"
+    gdp_tar_name="apache-hive-3.1.3-bin-gdp-${branch_sanitized}-${commit}-${ts}.tar.gz"
     echo "=== building tar ${gdp_tar_name} ==="
     if [ ! -f ./packaging/target/${file_name} ]; then \
       echo "ERROR: ./packaging/target/${file_name} is still missing after build"; \

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecMapper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecMapper.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.exec.mr;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +45,7 @@ import org.apache.hadoop.mapred.Mapper;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,6 +96,10 @@ public class ExecMapper extends MapReduceBase implements Mapper {
       // initialize map operator
       mo.initialize(job, null);
       mo.setChildren(job);
+
+      // defined self balance ReduceSinkOperator of bucketVersion
+      balanceRSOpbucketVersion(mo);
+
       l4j.info(mo.dump(0));
       // initialize map local work
       localWork = mrwork.getMapRedLocalWork();
@@ -128,6 +134,42 @@ public class ExecMapper extends MapReduceBase implements Mapper {
       }
     }
   }
+
+  /**
+   * defined-self balance ReduceSinkOperator of bucketVersion, keep values to sameness
+   * @param rootOp
+   */
+  private static void balanceRSOpbucketVersion(Operator rootOp){
+    List<Operator<? extends OperatorDesc>> needDealOps = new ArrayList<Operator<? extends OperatorDesc>>();
+    visitChildGetRSOps(rootOp, needDealOps);
+    int bucketVersion = -1;
+    for(Operator<? extends OperatorDesc> rsop : needDealOps){
+      if(rsop.getBucketingVersion() != 2 && rsop.getBucketingVersion() != 1){
+        rsop.setBucketingVersion(-1);
+      }
+      if(rsop.getBucketingVersion() > bucketVersion){
+        bucketVersion = rsop.getBucketingVersion();
+      }
+    }
+    for(Operator<? extends OperatorDesc> rsop : needDealOps){
+      l4j.info("update reduceSinkOperator name="+rsop.getName()+", opId="+rsop.getOperatorId()+", oldBucketVersion="+rsop.getBucketingVersion()+", newBucketVersion="+bucketVersion);
+      rsop.setBucketingVersion(bucketVersion);
+    }
+    needDealOps.clear();
+  }
+  private static void visitChildGetRSOps(Operator rootOp, List<Operator<? extends OperatorDesc>> needDealOps){
+    List<Operator<? extends OperatorDesc>> ops = rootOp.getChildOperators();
+    if(ops == null || ops.isEmpty()){
+      return;
+    }
+    for(Operator<? extends OperatorDesc> op : ops) {
+      if (op instanceof ReduceSinkOperator) {
+        needDealOps.add(op);
+      }
+      visitChildGetRSOps(op, needDealOps);
+    }
+  }
+
   @Override
   public void map(Object key, Object value, OutputCollector output,
       Reporter reporter) throws IOException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
@@ -219,6 +219,8 @@ public class TezCompiler extends TaskCompiler {
       new ConstantPropagate(ConstantPropagateOption.SHORTCUT).transform(procCtx.parseContext);
     }
 
+    updateBucketingVersion(procCtx);
+
   }
 
   private void runCycleAnalysisForPartitionPruning(OptimizeTezProcContext procCtx,
@@ -1447,6 +1449,34 @@ public class TezCompiler extends TaskCompiler {
         }
         deque.addAll(op.getChildOperators());
       }
+    }
+  }
+
+  /**
+   * Update bucketing version of ReduceSinkOp if exists old bucketing version table
+   * @param procCtx
+   */
+  private void updateBucketingVersion(OptimizeTezProcContext procCtx) {
+    // Fetch all the FileSinkOperators.
+    Set<ReduceSinkOperator> fsOpsAll = new HashSet<>();
+    for (TableScanOperator ts : procCtx.parseContext.getTopOps().values()){
+      Set<ReduceSinkOperator> fsOps = OperatorUtils.findOperators(ts, ReduceSinkOperator.class);
+      fsOpsAll.addAll(fsOps);
+    }
+
+    int bucketVersion = -1;
+    for (ReduceSinkOperator rsop : fsOpsAll){
+      if (rsop.getBucketingVersion() !=2 && rsop.getBucketingVersion() != 1){
+        rsop.setBucketingVersion(-1);
+      }
+      if (rsop.getBucketingVersion() > bucketVersion){
+        bucketVersion = rsop.getBucketingVersion();
+      }
+    }
+    for (Operator<? extends OperatorDesc> rsop : fsOpsAll){
+      LOG.info("tez update reduceSinkOperator name = " + rsop.getName() + ", opId = " + rsop.getOperatorId() + ", oldBucketVersion = "
+        + rsop.getBucketingVersion() + ", newBucketVersion = " + bucketVersion);
+      rsop.setBucketingVersion(bucketVersion);
     }
   }
 }


### PR DESCRIPTION
Why?
---
   - data-loss issue - with `mapred.reduce.tasks` property when using bucketed tables.
   - domain name getting replaced due to old patch on . to _

How?
---
- Patch applied
  - https://issues.apache.org/jira/browse/HIVE-22098
  - https://issues.apache.org/jira/browse/HIVE-23809


Testing?
---
- Tested on production by replacing the exec jar , getting expected count 


How to repro issue?
---

```python

SET hive.vectorized.execution.enabled=false;
SET mapred.reduce.tasks = 32;
SET hive.input.format = org.apache.hadoop.hive.ql.io.HiveInputFormat;


CREATE TABLE dropme_crm_lead_temp2 AS
SELECT
    4 AS organization_id
    , COALESCE(cmlu.master_id, '000MISSING') AS mid
    , COALESCE(cmlu.hq_company_id, COALESCE(cmlu.master_id, '_000MISSING')) as hq_company_id
    , '' AS export_id
    , c.id AS external_id
    , 'CRM Lead' AS external_source
    , CONCAT(c.first_name, ' ', c.last_name) AS full_name
    , COALESCE(c.department, '') AS department
    , c.phone
    , c.mobile_phone
    , c.email
    , c.role
    , c.job_title
    , c.first_name
    , c.last_name
--ACCOUNT'S LOCATION
    , '' address
    , '' zip
    , '' city
    , '' state
    , cmlu.country country
--CONTACT'S LOCATION
    , COALESCE(c.address, '') AS contact_address
    , COALESCE(c.zip, '') AS contact_zip
    , COALESCE(normalize_location(c.country, c.state, c.city).city, '') AS contact_city
    , COALESCE(normalize_location(c.country, c.state, '').state, '') AS contact_state
    , COALESCE_BLANKS(normalize_location(c.country, '', '').country, 'N/A') AS contact_country
    , COALESCE(crc.crm_contact_id, '') AS contact_id
    , concat("TEMP",string(rand())) AS crm_account_id
-- ACCOUNT OWNER DETAILS
    ,'' AS account_owner_id
    ,'' AS account_owner_first_name
    ,'' AS account_owner_last_name
    ,'' AS account_owner_email
    ,'' AS account_owner_title
    ,c.no_longer_with_company
    ,c.do_not_contact
    ,c.email_opt_out
    , 0 AS is_new
    , c.created
    , c.modified
    FROM
        crm_lead c
    LEFT OUTER JOIN company_master_lookup cmlu ON c.id = cmlu.external_id AND cmlu.external_source = 'CML'
    LEFT OUTER JOIN (
            SELECT * FROM (
                SELECT *, ROW_NUMBER() OVER (PARTITION BY email ORDER BY created, crm_contact_id) AS row_num
                FROM
                canonical_crm_contact
            ) t
            WHERE row_num = 1
        ) crc ON (c.email = crc.email)
    LEFT JOIN tmp_crm_contact cc ON c.email = cc.email
    WHERE
            c.email != '' and c.email IS NOT NULL and NOT EXISTS (select email from crm_lead_email_tmp tmp WHERE c.email = tmp.email )
    AND ( c.converted_contact_id <> cc.id  OR
        c.converted_contact_id = '' OR
        c.converted_contact_id IS NULL)
;

select count(distinct mid) from dropme_crm_lead_temp2;
2658    (expected - 51359)
```